### PR TITLE
Add Swagger specification and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # Laryo
 micro framework Flutter adapté à Laravel te permettra de fluidifier et standardiser le développement fullstack mobile + API Laravel.
+
+## Swagger UI
+
+Pour consulter la documentation de l'API :
+
+1. Rendez-vous dans le dossier `laravel` :
+
+```bash
+cd laravel
+```
+
+2. Lancez le serveur de développement :
+
+```bash
+php artisan serve
+```
+
+3. Ouvrez votre navigateur à l'adresse [http://localhost:8000/swagger](http://localhost:8000/swagger).
+
+La documentation se base sur le fichier `public/swagger.yaml`.

--- a/laravel/public/swagger.yaml
+++ b/laravel/public/swagger.yaml
@@ -2,4 +2,152 @@ openapi: 3.0.0
 info:
   title: API Laravel
   version: 1.0.0
-paths: {}
+servers:
+  - url: http://localhost:8000
+paths:
+  /register:
+    post:
+      summary: Register a new user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterRequest'
+      responses:
+        '201':
+          description: User registered
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+  /login:
+    post:
+      summary: Authenticate a user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+      responses:
+        '200':
+          description: Login successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthToken'
+  /logout:
+    post:
+      summary: Logout the current user
+      security:
+        - BearerAuth: []
+      responses:
+        '204':
+          description: Logged out successfully
+  /profile:
+    get:
+      summary: Retrieve the current user's profile
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Profile information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+    patch:
+      summary: Update the user's profile
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateProfileRequest'
+      responses:
+        '200':
+          description: Profile updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+    delete:
+      summary: Delete the user's account
+      security:
+        - BearerAuth: []
+      responses:
+        '204':
+          description: Account deleted
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    RegisterRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+        password_confirmation:
+          type: string
+      required:
+        - name
+        - email
+        - password
+        - password_confirmation
+    LoginRequest:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+      required:
+        - email
+        - password
+    UpdateProfileRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+        email_verified_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AuthToken:
+      type: object
+      properties:
+        token:
+          type: string
+        user:
+          $ref: '#/components/schemas/User'


### PR DESCRIPTION
## Summary
- add example API specification under `public/swagger.yaml`
- document how to open Swagger UI in the README

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686ac40f33c0832fb871cda212fb21b8