### PR TITLE
Implement basic API endpoints with Sanctum

### DIFF
--- a/laravel/app/Http/Controllers/API/AuthController.php
+++ b/laravel/app/Http/Controllers/API/AuthController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rules;
+use Illuminate\Validation\ValidationException;
+
+class AuthController extends Controller
+{
+    public function register(Request $request)
+    {
+        $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:users,email'],
+            'password' => ['required', 'confirmed', Rules\Password::defaults()],
+        ]);
+
+        $user = User::create([
+            'name' => $request->name,
+            'email' => $request->email,
+            'password' => Hash::make($request->password),
+        ]);
+
+        $token = $user->createToken('auth_token')->plainTextToken;
+
+        return response()->json([
+            'token' => $token,
+            'user' => $user,
+        ], 201);
+    }
+
+    public function login(Request $request)
+    {
+        $request->validate([
+            'email' => ['required', 'string', 'email'],
+            'password' => ['required', 'string'],
+        ]);
+
+        $user = User::where('email', $request->email)->first();
+
+        if (! $user || ! Hash::check($request->password, $user->password)) {
+            throw ValidationException::withMessages([
+                'email' => ['The provided credentials are incorrect.'],
+            ]);
+        }
+
+        $user->tokens()->delete();
+
+        $token = $user->createToken('auth_token')->plainTextToken;
+
+        return response()->json([
+            'token' => $token,
+            'user' => $user,
+        ]);
+    }
+
+    public function logout(Request $request)
+    {
+        $request->user()->currentAccessToken()->delete();
+
+        return response()->json(null, 204);
+    }
+}

--- a/laravel/app/Http/Controllers/API/ProfileController.php
+++ b/laravel/app/Http/Controllers/API/ProfileController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\ProfileUpdateRequest;
+use Illuminate\Http\Request;
+
+class ProfileController extends Controller
+{
+    public function show(Request $request)
+    {
+        return response()->json($request->user());
+    }
+
+    public function update(ProfileUpdateRequest $request)
+    {
+        $user = $request->user();
+        $user->fill($request->validated());
+
+        if ($user->isDirty('email')) {
+            $user->email_verified_at = null;
+        }
+
+        $user->save();
+
+        return response()->json($user);
+    }
+
+    public function destroy(Request $request)
+    {
+        $user = $request->user();
+        $user->tokens()->delete();
+        $user->delete();
+
+        return response()->json(null, 204);
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/laravel/public/swagger.yaml
+++ b/laravel/public/swagger.yaml
@@ -5,7 +5,7 @@ info:
 servers:
   - url: http://localhost:8000
 paths:
-  /register:
+  /api/register:
     post:
       summary: Register a new user
       requestBody:
@@ -21,7 +21,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
-  /login:
+  /api/login:
     post:
       summary: Authenticate a user
       requestBody:
@@ -37,7 +37,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AuthToken'
-  /logout:
+  /api/logout:
     post:
       summary: Logout the current user
       security:
@@ -45,7 +45,7 @@ paths:
       responses:
         '204':
           description: Logged out successfully
-  /profile:
+  /api/profile:
     get:
       summary: Retrieve the current user's profile
       security:

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,0 +1,18 @@
+<?php
+
+use App\Http\Controllers\API\AuthController;
+use App\Http\Controllers\API\ProfileController;
+use Illuminate\Support\Facades\Route;
+
+Route::prefix('api')->group(function () {
+    Route::post('/register', [AuthController::class, 'register']);
+    Route::post('/login', [AuthController::class, 'login']);
+
+    Route::middleware('auth:sanctum')->group(function () {
+        Route::post('/logout', [AuthController::class, 'logout']);
+
+        Route::get('/profile', [ProfileController::class, 'show']);
+        Route::patch('/profile', [ProfileController::class, 'update']);
+        Route::delete('/profile', [ProfileController::class, 'destroy']);
+    });
+});


### PR DESCRIPTION
## Summary
- add API controllers for authentication and profile management
- register `/api` routes using Sanctum for auth
- hook new API route file into the application bootstrap
- update Swagger spec with `/api` endpoints

## Testing
- `composer install` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b16b7de70832fbdbb48216d893d60