### PR TITLE
Use secure storage for auth tokens

### DIFF
--- a/flutterapp/lib/main.dart
+++ b/flutterapp/lib/main.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'services/auth_service.dart';
+import 'services/secure_auth_service.dart';
 import 'screens/login_screen.dart';
 import 'screens/profile_screen.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await dotenv.load(fileName: '.env');
-  final auth = AuthService();
+  final auth = SecureAuthService();
   final token = await auth.getToken();
   runApp(MyApp(initialToken: token));
 }

--- a/flutterapp/lib/screens/login_screen.dart
+++ b/flutterapp/lib/screens/login_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import '../services/api_service.dart';
-import '../services/auth_service.dart';
+import '../services/secure_auth_service.dart';
 import 'profile_screen.dart';
 import 'registration_screen.dart';
 
@@ -18,7 +18,7 @@ class _LoginScreenState extends State<LoginScreen> {
   bool _isLoading = false;
 
   final ApiService _api = ApiService();
-  final AuthService _auth = AuthService();
+  final SecureAuthService _auth = SecureAuthService();
 
   Future<void> _submit() async {
     if (!_formKey.currentState!.validate()) return;

--- a/flutterapp/lib/screens/profile_screen.dart
+++ b/flutterapp/lib/screens/profile_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import '../services/api_service.dart';
-import '../services/auth_service.dart';
+import '../services/secure_auth_service.dart';
 import 'login_screen.dart';
 
 class ProfileScreen extends StatefulWidget {
@@ -12,7 +12,7 @@ class ProfileScreen extends StatefulWidget {
 
 class _ProfileScreenState extends State<ProfileScreen> {
   final ApiService _api = ApiService();
-  final AuthService _auth = AuthService();
+  final SecureAuthService _auth = SecureAuthService();
   Map<String, dynamic>? _profile;
 
   @override

--- a/flutterapp/lib/services/secure_auth_service.dart
+++ b/flutterapp/lib/services/secure_auth_service.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+class SecureAuthService {
+  static const _tokenKey = 'auth_token';
+
+  final FlutterSecureStorage _storage;
+
+  SecureAuthService({FlutterSecureStorage? storage})
+      : _storage = storage ?? const FlutterSecureStorage();
+
+  Future<void> saveToken(String token) async {
+    await _storage.write(key: _tokenKey, value: token);
+  }
+
+  Future<String?> getToken() async {
+    return await _storage.read(key: _tokenKey);
+  }
+
+  Future<void> clearToken() async {
+    await _storage.delete(key: _tokenKey);
+  }
+}

--- a/flutterapp/pubspec.yaml
+++ b/flutterapp/pubspec.yaml
@@ -36,11 +36,12 @@ dependencies:
   cupertino_icons: ^1.0.8
   http: ^1.1.0
   flutter_dotenv: ^5.0.2
-  shared_preferences: ^2.2.2
+  flutter_secure_storage: ^9.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_secure_storage_mocks: ^1.0.1
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/flutterapp/test/secure_auth_service_test.dart
+++ b/flutterapp/test/secure_auth_service_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_secure_storage_mocks/flutter_secure_storage_mocks.dart';
+import 'package:flutterapp/services/secure_auth_service.dart';
+
+void main() {
+  test('save and retrieve token', () async {
+    final storage = MockFlutterSecureStorage();
+    final service = SecureAuthService(storage: storage);
+    await service.saveToken('abc');
+    final token = await service.getToken();
+    expect(token, 'abc');
+    await service.clearToken();
+    final cleared = await service.getToken();
+    expect(cleared, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- add `flutter_secure_storage` dependency and its mock package
- introduce `SecureAuthService` using `FlutterSecureStorage`
- update main and screens to use `SecureAuthService`
- provide tests for the new service

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b16b9b610832fa90da76e8a808b30