### PR TITLE
Add Socialite SSO with Sanctum

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,28 @@ flutter run --dart-define=API_URL=http://localhost:8000
 
 In Laravel, configure `APP_URL` and your database credentials in `.env`.
 
+## SSO Authentication
+
+After installing the dependencies with:
+
+```bash
+composer require laravel/socialite laravel/sanctum
+```
+
+You can authenticate users via third party providers.
+
+- `GET /api/sso/redirect/{provider}` redirects the user to the chosen provider.
+- `GET /api/sso/callback/{provider}` returns a JSON response containing a Sanctum token.
+
+Example response:
+
+```json
+{
+  "token": "<token>",
+  "user": { /* user attributes */ }
+}
+```
+
 ## Swagger UI
 
 Pour consulter la documentation de l'API :

--- a/laravel/app/Http/Controllers/SSOController.php
+++ b/laravel/app/Http/Controllers/SSOController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Laravel\Socialite\Facades\Socialite;
+use App\Models\User;
+
+class SSOController extends Controller
+{
+    public function redirect(string $provider)
+    {
+        return Socialite::driver($provider)->stateless()->redirect();
+    }
+
+    public function callback(Request $request, string $provider)
+    {
+        $socialiteUser = Socialite::driver($provider)->stateless()->user();
+
+        $user = User::firstOrCreate(
+            ['email' => $socialiteUser->getEmail()],
+            ['name' => $socialiteUser->getName() ?: $socialiteUser->getNickname()]
+        );
+
+        $token = $user->createToken('sso')->plainTextToken;
+
+        return response()->json([
+            'token' => $token,
+            'user' => $user,
+        ]);
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Laravel\Sanctum\HasApiTokens;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Spatie\Permission\Traits\HasRoles;
@@ -12,7 +13,7 @@ use Spatie\Permission\Traits\HasRoles;
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable;
     use HasRoles;
 
     /**

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/laravel/composer.json
+++ b/laravel/composer.json
@@ -10,7 +10,9 @@
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
         "spatie/laravel-permission": "^6.20",
-        "wotz/laravel-swagger-ui": "^1.2"
+        "wotz/laravel-swagger-ui": "^1.2",
+        "laravel/socialite": "^5.8",
+        "laravel/sanctum": "^4.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/laravel/config/sanctum.php
+++ b/laravel/config/sanctum.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
+        '%s%s',
+        'localhost,localhost:8000',
+        env('APP_URL') ? ',' . parse_url(env('APP_URL'), PHP_URL_HOST) : ''
+    ))),
+];

--- a/laravel/config/services.php
+++ b/laravel/config/services.php
@@ -35,4 +35,16 @@ return [
         ],
     ],
 
+    'github' => [
+        'client_id' => env('GITHUB_CLIENT_ID'),
+        'client_secret' => env('GITHUB_CLIENT_SECRET'),
+        'redirect' => env('APP_URL').'/api/sso/callback/github',
+    ],
+
+    'google' => [
+        'client_id' => env('GOOGLE_CLIENT_ID'),
+        'client_secret' => env('GOOGLE_CLIENT_SECRET'),
+        'redirect' => env('APP_URL').'/api/sso/callback/google',
+    ],
+
 ];

--- a/laravel/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/laravel/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/laravel/public/swagger.yaml
+++ b/laravel/public/swagger.yaml
@@ -81,6 +81,34 @@ paths:
       responses:
         '204':
           description: Account deleted
+  /api/sso/redirect/{provider}:
+    get:
+      summary: Redirect to SSO provider
+      parameters:
+        - name: provider
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '302':
+          description: Redirecting to provider
+  /api/sso/callback/{provider}:
+    get:
+      summary: Handle SSO callback
+      parameters:
+        - name: provider
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: SSO login successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthToken'
 components:
   securitySchemes:
     BearerAuth:

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,0 +1,7 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\SSOController;
+
+Route::get('/sso/redirect/{provider}', [SSOController::class, 'redirect']);
+Route::get('/sso/callback/{provider}', [SSOController::class, 'callback']);


### PR DESCRIPTION
## Summary
- install `laravel/socialite` and `laravel/sanctum`
- issue Sanctum token on SSO callback
- wire `/api/sso/redirect/{provider}` and `/api/sso/callback/{provider}` routes
- expose API route file in bootstrap config
- document SSO usage in README
- update Swagger docs

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b16d1e6a8832fb01bcaabd601465c