### PR TITLE
Add feature and UI template support

### DIFF
--- a/laravel/app/Http/Controllers/FeatureController.php
+++ b/laravel/app/Http/Controllers/FeatureController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Feature;
+use Illuminate\Http\JsonResponse;
+
+class FeatureController extends Controller
+{
+    /**
+     * Display a listing of features.
+     */
+    public function index(): JsonResponse
+    {
+        return response()->json(Feature::all());
+    }
+}

--- a/laravel/app/Http/Controllers/UiTemplateController.php
+++ b/laravel/app/Http/Controllers/UiTemplateController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\UiTemplate;
+use Illuminate\Http\JsonResponse;
+
+class UiTemplateController extends Controller
+{
+    /**
+     * Display a listing of UI templates.
+     */
+    public function index(): JsonResponse
+    {
+        return response()->json(UiTemplate::all());
+    }
+}

--- a/laravel/app/Models/Feature.php
+++ b/laravel/app/Models/Feature.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Feature extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'key',
+        'enabled',
+        'description',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'enabled' => 'boolean',
+        ];
+    }
+}

--- a/laravel/app/Models/UiTemplate.php
+++ b/laravel/app/Models/UiTemplate.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class UiTemplate extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'key',
+        'value',
+        'type',
+    ];
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/laravel/database/migrations/2025_07_09_000000_create_ui_templates_table.php
+++ b/laravel/database/migrations/2025_07_09_000000_create_ui_templates_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('ui_templates', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->text('value');
+            $table->string('type');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ui_templates');
+    }
+};

--- a/laravel/database/migrations/2025_07_09_000001_create_features_table.php
+++ b/laravel/database/migrations/2025_07_09_000001_create_features_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('features', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->boolean('enabled')->default(false);
+            $table->string('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('features');
+    }
+};

--- a/laravel/database/seeders/DatabaseSeeder.php
+++ b/laravel/database/seeders/DatabaseSeeder.php
@@ -19,5 +19,10 @@ class DatabaseSeeder extends Seeder
             'name' => 'Test User',
             'email' => 'test@example.com',
         ]);
+
+        $this->call([
+            UiTemplateSeeder::class,
+            FeatureSeeder::class,
+        ]);
     }
 }

--- a/laravel/database/seeders/FeatureSeeder.php
+++ b/laravel/database/seeders/FeatureSeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Feature;
+use Illuminate\Database\Seeder;
+
+class FeatureSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Feature::create([
+            'key' => 'dark_mode',
+            'enabled' => true,
+            'description' => 'Enable dark theme for users',
+        ]);
+    }
+}

--- a/laravel/database/seeders/UiTemplateSeeder.php
+++ b/laravel/database/seeders/UiTemplateSeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\UiTemplate;
+use Illuminate\Database\Seeder;
+
+class UiTemplateSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        UiTemplate::create([
+            'key' => 'main_layout',
+            'value' => '<div>Main Layout</div>',
+            'type' => 'html',
+        ]);
+    }
+}

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+
+use App\Http\Controllers\FeatureController;
+use App\Http\Controllers\UiTemplateController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/ui-template', [UiTemplateController::class, 'index']);
+Route::get('/features', [FeatureController::class, 'index']);


### PR DESCRIPTION
## Summary
- create migrations for `ui_templates` and `features`
- add `UiTemplate` and `Feature` models
- implement controllers exposing JSON API
- define API routes and enable them in bootstrap
- seed some sample templates and features

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b16d293a8832fa9d8f20105967b11