### PR TITLE
Add feature and template services

### DIFF
--- a/flutterapp/lib/main.dart
+++ b/flutterapp/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'services/auth_service.dart';
+import 'services/feature_manager_service.dart';
+import 'services/template_service.dart';
 import 'screens/login_screen.dart';
 import 'screens/profile_screen.dart';
 
@@ -8,20 +10,32 @@ Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await dotenv.load(fileName: '.env');
   final auth = AuthService();
+
+  await Future.wait([
+    featureManager.loadFeatures(),
+    templateService.loadTemplate(),
+  ]);
+
   final token = await auth.getToken();
   runApp(MyApp(initialToken: token));
 }
 
 class MyApp extends StatelessWidget {
   final String? initialToken;
-  const MyApp({super.key, this.initialToken});
+
+  const MyApp({
+    super.key,
+    required this.initialToken,
+  });
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: templateService.primaryColor ?? Colors.deepPurple,
+        ),
       ),
       home: initialToken == null ? const LoginScreen() : const ProfileScreen(),
     );

--- a/flutterapp/lib/screens/profile_screen.dart
+++ b/flutterapp/lib/screens/profile_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import '../services/api_service.dart';
 import '../services/auth_service.dart';
+import '../services/feature_manager_service.dart';
+import '../services/template_service.dart';
 import 'login_screen.dart';
 
 class ProfileScreen extends StatefulWidget {
@@ -46,9 +48,26 @@ class _ProfileScreenState extends State<ProfileScreen> {
         ],
       ),
       body: Center(
-        child: _profile == null
-            ? const CircularProgressIndicator()
-            : Text('Hello ${_profile!['name'] ?? ''}'),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            if (templateService.logoUrl != null)
+              Image.network(templateService.logoUrl!, height: 80),
+            Text(templateService.welcomeText),
+            const SizedBox(height: 16),
+            _profile == null
+                ? const CircularProgressIndicator()
+                : Text('Hello ${_profile!['name'] ?? ''}'),
+            if (featureManager.isEnabled('new_profile_banner'))
+              const Padding(
+                padding: EdgeInsets.only(top: 8.0),
+                child: Text(
+                  'New Feature Enabled!',
+                  style: TextStyle(fontWeight: FontWeight.bold),
+                ),
+              ),
+          ],
+        ),
       ),
     );
   }

--- a/flutterapp/lib/services/feature_manager_service.dart
+++ b/flutterapp/lib/services/feature_manager_service.dart
@@ -1,0 +1,35 @@
+import 'dart:convert';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+class FeatureManagerService {
+  final String baseUrl = dotenv.env['API_BASE_URL'] ?? '';
+  static const _cacheKey = 'feature_flags';
+  Map<String, bool> _flags = {};
+
+  Future<void> loadFeatures() async {
+    final prefs = await SharedPreferences.getInstance();
+    try {
+      final response = await http.get(Uri.parse('$baseUrl/api/features'));
+      if (response.statusCode == 200) {
+        final Map<String, dynamic> data = jsonDecode(response.body);
+        _flags = data.map((k, v) => MapEntry(k, v as bool));
+        await prefs.setString(_cacheKey, jsonEncode(_flags));
+        return;
+      }
+    } catch (_) {
+      // ignore errors and fall back to cache
+    }
+    final cached = prefs.getString(_cacheKey);
+    if (cached != null) {
+      final Map<String, dynamic> data = jsonDecode(cached);
+      _flags = data.map((k, v) => MapEntry(k, v as bool));
+    }
+  }
+
+  bool isEnabled(String name) => _flags[name] ?? false;
+}
+
+final featureManager = FeatureManagerService();

--- a/flutterapp/lib/services/template_service.dart
+++ b/flutterapp/lib/services/template_service.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:http/http.dart' as http;
+
+class TemplateService {
+  final String baseUrl = dotenv.env['API_BASE_URL'] ?? '';
+  Map<String, dynamic> _template = {};
+
+  Future<void> loadTemplate() async {
+    try {
+      final response = await http.get(Uri.parse('$baseUrl/api/ui-template'));
+      if (response.statusCode == 200) {
+        _template = jsonDecode(response.body) as Map<String, dynamic>;
+      }
+    } catch (_) {
+      // ignore fetch errors
+    }
+  }
+
+  Color? get primaryColor => _parseColor(_template['primaryColor']);
+  String? get logoUrl => _template['logoUrl'] as String?;
+  String get welcomeText => _template['welcomeText'] as String? ?? 'Welcome';
+
+  Color? _parseColor(dynamic value) {
+    if (value is String && value.startsWith('#')) {
+      return Color(int.parse(value.substring(1), radix: 16) + 0xFF000000);
+    }
+    return null;
+  }
+}
+
+final templateService = TemplateService();

--- a/flutterapp/test/widget_test.dart
+++ b/flutterapp/test/widget_test.dart
@@ -4,7 +4,7 @@ import 'package:flutterapp/main.dart';
 
 void main() {
   testWidgets('Shows login screen', (WidgetTester tester) async {
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const MyApp(initialToken: null));
     expect(find.text('Login'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add FeatureManagerService for caching feature flags
- add TemplateService for UI theming data
- initialize services in `main.dart`
- show example usage in `ProfileScreen`
- update test for new app signature

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b16d41e68832fb760c81450698f9f