### PR TITLE
Add auth and Flutter service docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,49 @@ Pour consulter la documentation de l'API :
 3. Ouvrez votre navigateur à l'adresse [http://localhost:8000/swagger](http://localhost:8000/swagger).
 
 La documentation se base sur le fichier `public/swagger.yaml`.
+
+## Authentication with Socialite & Sanctum
+
+This boilerplate can be extended to support OAuth login and API tokens. Install
+the packages and publish Sanctum's configuration:
+
+```bash
+cd laravel
+composer require laravel/socialite laravel/sanctum
+php artisan vendor:publish --provider="Laravel\Sanctum\SanctumServiceProvider"
+```
+
+Add Sanctum's middleware to the `api` group in `app/Http/Kernel.php` and run the
+migrations. Each Socialite provider (Google, GitHub…) requires credentials in
+`config/services.php` and matching variables in `.env`:
+
+```php
+'github' => [
+    'client_id' => env('GITHUB_CLIENT_ID'),
+    'client_secret' => env('GITHUB_CLIENT_SECRET'),
+    'redirect' => env('GITHUB_REDIRECT_URI'),
+],
+```
+
+After configuration you can authenticate via the provider and receive a Sanctum
+token for the Flutter app.
+
+## Running migrations for `ui_templates` and `features`
+
+When installing optional modules such as `ui_templates` or `features`, run their
+migrations after publishing the package files:
+
+```bash
+php artisan migrate --path=vendor/vendor-name/ui_templates/database/migrations
+php artisan migrate --path=vendor/vendor-name/features/database/migrations
+```
+
+Adjust the path according to where the packages store their migrations.
+
+## Flutter services
+
+The mobile project exposes a small API client in `lib/services`. `ApiService`
+reads `API_BASE_URL` from the Flutter `.env` file and provides methods for
+`login`, `register` and retrieving the authenticated profile. Tokens are
+persisted using `AuthService`, backed by `shared_preferences`. These services
+consume the Laravel endpoints described in `swagger.yaml`.

--- a/flutterapp/README.md
+++ b/flutterapp/README.md
@@ -14,3 +14,10 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Services
+
+`ApiService` in `lib/services/api_service.dart` wraps the HTTP calls to the
+Laravel API (login, register and profile). The base URL comes from the
+`API_BASE_URL` environment variable. Tokens returned by the API are persisted via
+`AuthService` so the user stays logged in.


### PR DESCRIPTION
## Summary
- document Socialite provider and Sanctum configuration
- describe extra migrations for `ui_templates` and `features`
- add explanation of Flutter services and how the app calls the API

## Testing
- `composer test` *(fails: composer missing)*
- `flutter test` *(fails: flutter missing)*

------
https://chatgpt.com/codex/tasks/task_e_686b16d5c1c0832fae1e2c3d450ab039