### PR TITLE
Add user profile table and API

### DIFF
--- a/flutterapp/lib/screens/profile_screen.dart
+++ b/flutterapp/lib/screens/profile_screen.dart
@@ -14,6 +14,9 @@ class _ProfileScreenState extends State<ProfileScreen> {
   final ApiService _api = ApiService();
   final AuthService _auth = AuthService();
   Map<String, dynamic>? _profile;
+  final _avatarController = TextEditingController();
+  final _bioController = TextEditingController();
+  final _languageController = TextEditingController();
 
   @override
   void initState() {
@@ -25,7 +28,22 @@ class _ProfileScreenState extends State<ProfileScreen> {
     final token = await _auth.getToken();
     if (token == null) return;
     final data = await _api.getProfile(token);
-    setState(() => _profile = data);
+    setState(() {
+      _profile = data;
+      _avatarController.text = data?['avatar_url'] ?? '';
+      _bioController.text = data?['bio'] ?? '';
+      _languageController.text = data?['language'] ?? '';
+    });
+  }
+
+  Future<void> _save() async {
+    final token = await _auth.getToken();
+    if (token == null) return;
+    await _api.updateProfile(token,
+        avatarUrl: _avatarController.text,
+        bio: _bioController.text,
+        language: _languageController.text);
+    await _loadProfile();
   }
 
   Future<void> _logout() async {
@@ -45,11 +63,33 @@ class _ProfileScreenState extends State<ProfileScreen> {
           IconButton(onPressed: _logout, icon: const Icon(Icons.logout))
         ],
       ),
-      body: Center(
-        child: _profile == null
-            ? const CircularProgressIndicator()
-            : Text('Hello ${_profile!['name'] ?? ''}'),
-      ),
+      body: _profile == null
+          ? const Center(child: CircularProgressIndicator())
+          : Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                children: [
+                  TextField(
+                    controller: _avatarController,
+                    decoration: const InputDecoration(labelText: 'Avatar URL'),
+                  ),
+                  TextField(
+                    controller: _bioController,
+                    decoration: const InputDecoration(labelText: 'Bio'),
+                  ),
+                  TextField(
+                    controller: _languageController,
+                    decoration:
+                        const InputDecoration(labelText: 'Language'),
+                  ),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: _save,
+                    child: const Text('Save'),
+                  ),
+                ],
+              ),
+            ),
     );
   }
 }

--- a/flutterapp/lib/services/api_service.dart
+++ b/flutterapp/lib/services/api_service.dart
@@ -37,4 +37,21 @@ class ApiService {
     }
     return null;
   }
+
+  Future<bool> updateProfile(String token,
+      {String? avatarUrl, String? bio, String? language}) async {
+    final response = await http.patch(
+      Uri.parse('$baseUrl/api/profile'),
+      headers: {
+        'Authorization': 'Bearer $token',
+        'Content-Type': 'application/json'
+      },
+      body: jsonEncode({
+        'avatar_url': avatarUrl,
+        'bio': bio,
+        'language': language,
+      }),
+    );
+    return response.statusCode == 200;
+  }
 }

--- a/laravel/app/Http/Controllers/Api/UserProfileController.php
+++ b/laravel/app/Http/Controllers/Api/UserProfileController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use App\Models\UserProfile;
+
+class UserProfileController extends Controller
+{
+    public function show(Request $request): JsonResponse
+    {
+        $profile = $request->user()->profile;
+        return response()->json($profile);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'avatar_url' => ['nullable', 'string'],
+            'bio' => ['nullable', 'string'],
+            'language' => ['nullable', 'string', 'max:10'],
+        ]);
+
+        $profile = $request->user()->profile()->create($data);
+        return response()->json($profile, 201);
+    }
+
+    public function update(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'avatar_url' => ['nullable', 'string'],
+            'bio' => ['nullable', 'string'],
+            'language' => ['nullable', 'string', 'max:10'],
+        ]);
+
+        $profile = $request->user()->profile;
+        $profile->update($data);
+        return response()->json($profile);
+    }
+
+    public function destroy(Request $request): JsonResponse
+    {
+        $profile = $request->user()->profile;
+        $profile->delete();
+        return response()->json(null, 204);
+    }
+}

--- a/laravel/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/laravel/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -41,6 +41,8 @@ class RegisteredUserController extends Controller
             'password' => Hash::make($request->password),
         ]);
 
+        $user->profile()->create();
+
         event(new Registered($user));
 
         Auth::login($user);

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Spatie\Permission\Traits\HasRoles;
+use App\Models\UserProfile;
 
 
 class User extends Authenticatable
@@ -47,5 +48,10 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function profile()
+    {
+        return $this->hasOne(UserProfile::class);
     }
 }

--- a/laravel/app/Models/UserProfile.php
+++ b/laravel/app/Models/UserProfile.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class UserProfile extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'avatar_url',
+        'bio',
+        'language',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/laravel/database/migrations/2025_07_06_160000_create_user_profiles_table.php
+++ b/laravel/database/migrations/2025_07_06_160000_create_user_profiles_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('user_profiles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('avatar_url')->nullable();
+            $table->text('bio')->nullable();
+            $table->string('language', 10)->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('user_profiles');
+    }
+};

--- a/laravel/public/swagger.yaml
+++ b/laravel/public/swagger.yaml
@@ -56,7 +56,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/UserProfile'
     patch:
       summary: Update the user's profile
       security:
@@ -73,7 +73,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/UserProfile'
     delete:
       summary: Delete the user's account
       security:
@@ -124,6 +124,12 @@ components:
         email:
           type: string
           format: email
+        avatar_url:
+          type: string
+        bio:
+          type: string
+        language:
+          type: string
     User:
       type: object
       properties:
@@ -138,6 +144,27 @@ components:
           type: string
           format: date-time
           nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        profile:
+          $ref: '#/components/schemas/UserProfile'
+    UserProfile:
+      type: object
+      properties:
+        id:
+          type: integer
+        user_id:
+          type: integer
+        avatar_url:
+          type: string
+        bio:
+          type: string
+        language:
+          type: string
         created_at:
           type: string
           format: date-time

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,0 +1,11 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\UserProfileController;
+
+Route::middleware('auth')->group(function () {
+    Route::get('/profile', [UserProfileController::class, 'show']);
+    Route::post('/profile', [UserProfileController::class, 'store']);
+    Route::patch('/profile', [UserProfileController::class, 'update']);
+    Route::delete('/profile', [UserProfileController::class, 'destroy']);
+});


### PR DESCRIPTION
## Summary
- add `user_profiles` model and migration
- relate users to a profile and create it at registration
- provide API endpoints for reading/updating the profile
- expose new API route file in bootstrap
- document new schema in Swagger
- allow editing profile fields in Flutter

## Testing
- `php artisan test` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b18549c6c832fb6f3dd5e9fd361dc