### PR TITLE
Add version check feature

### DIFF
--- a/flutterapp/lib/main.dart
+++ b/flutterapp/lib/main.dart
@@ -1,20 +1,61 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'dart:io';
+
 import 'services/auth_service.dart';
+import 'services/api_service.dart';
 import 'screens/login_screen.dart';
 import 'screens/profile_screen.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await dotenv.load(fileName: '.env');
+  final info = await PackageInfo.fromPlatform();
+  final platform = Platform.isIOS ? 'ios' : 'android';
+  final versionInfo =
+      await ApiService().checkVersion(platform, info.version) ?? {};
   final auth = AuthService();
   final token = await auth.getToken();
-  runApp(MyApp(initialToken: token));
+  runApp(MyApp(initialToken: token, versionInfo: versionInfo));
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   final String? initialToken;
-  const MyApp({super.key, this.initialToken});
+  final Map<String, dynamic> versionInfo;
+  const MyApp({super.key, this.initialToken, required this.versionInfo});
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  @override
+  void initState() {
+    super.initState();
+    final info = widget.versionInfo;
+    if (info['update_required'] == true) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        showDialog(
+          context: context,
+          barrierDismissible: !(info['force_update'] == true),
+          builder: (_) => AlertDialog(
+            title: const Text('Update Available'),
+            content: Text(info['changelog'] ?? ''),
+            actions: [
+              if (!(info['force_update'] == true))
+                TextButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: const Text('Later')),
+              TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('Update')),
+            ],
+          ),
+        );
+      });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -23,7 +64,8 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      home: initialToken == null ? const LoginScreen() : const ProfileScreen(),
+      home:
+          widget.initialToken == null ? const LoginScreen() : const ProfileScreen(),
     );
   }
 }

--- a/flutterapp/lib/services/api_service.dart
+++ b/flutterapp/lib/services/api_service.dart
@@ -37,4 +37,15 @@ class ApiService {
     }
     return null;
   }
+
+  Future<Map<String, dynamic>?> checkVersion(
+      String platform, String version) async {
+    final uri =
+        Uri.parse('$baseUrl/api/version-check?platform=$platform&version=$version');
+    final response = await http.get(uri);
+    if (response.statusCode == 200) {
+      return jsonDecode(response.body) as Map<String, dynamic>;
+    }
+    return null;
+  }
 }

--- a/flutterapp/pubspec.yaml
+++ b/flutterapp/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   http: ^1.1.0
   flutter_dotenv: ^5.0.2
   shared_preferences: ^2.2.2
+  package_info_plus: ^5.0.1
 
 dev_dependencies:
   flutter_test:

--- a/laravel/app/Http/Controllers/VersionCheckController.php
+++ b/laravel/app/Http/Controllers/VersionCheckController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\AppVersion;
+use Illuminate\Http\Request;
+
+class VersionCheckController extends Controller
+{
+    public function __invoke(Request $request)
+    {
+        $data = $request->validate([
+            'platform' => 'required|string',
+            'version' => 'required|string',
+        ]);
+
+        $appVersion = AppVersion::where('platform', $data['platform'])->first();
+
+        if (! $appVersion) {
+            return response()->json(['message' => 'Platform not found'], 404);
+        }
+
+        $updateRequired = version_compare($data['version'], $appVersion->current_version, '<');
+        $forceUpdate = $appVersion->force_update ||
+            version_compare($data['version'], $appVersion->min_version, '<');
+
+        return response()->json([
+            'update_required' => $updateRequired,
+            'force_update' => $forceUpdate,
+            'current_version' => $appVersion->current_version,
+            'min_version' => $appVersion->min_version,
+            'changelog' => $appVersion->changelog,
+        ]);
+    }
+}

--- a/laravel/app/Models/AppVersion.php
+++ b/laravel/app/Models/AppVersion.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AppVersion extends Model
+{
+    protected $fillable = [
+        'platform',
+        'min_version',
+        'current_version',
+        'changelog',
+        'force_update',
+    ];
+}

--- a/laravel/database/migrations/2025_07_07_000000_create_app_versions_table.php
+++ b/laravel/database/migrations/2025_07_07_000000_create_app_versions_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('app_versions', function (Blueprint $table) {
+            $table->id();
+            $table->string('platform');
+            $table->string('min_version');
+            $table->string('current_version');
+            $table->text('changelog')->nullable();
+            $table->boolean('force_update')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('app_versions');
+    }
+};

--- a/laravel/public/swagger.yaml
+++ b/laravel/public/swagger.yaml
@@ -81,6 +81,39 @@ paths:
       responses:
         '204':
           description: Account deleted
+
+  /api/version-check:
+    get:
+      summary: Check if a new app version is available
+      parameters:
+        - in: query
+          name: platform
+          schema:
+            type: string
+          required: true
+        - in: query
+          name: version
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Version information
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  update_required:
+                    type: boolean
+                  force_update:
+                    type: boolean
+                  current_version:
+                    type: string
+                  min_version:
+                    type: string
+                  changelog:
+                    type: string
 components:
   securitySchemes:
     BearerAuth:

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\VersionCheckController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -18,3 +19,5 @@ Route::middleware('auth')->group(function () {
 });
 
 require __DIR__.'/auth.php';
+
+Route::get('/api/version-check', VersionCheckController::class);


### PR DESCRIPTION
## Summary
- create `app_versions` table
- expose `/api/version-check` endpoint
- document version check in swagger
- check app version on Flutter startup and show update prompt

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b18556c90832f8a29d1a1759549ac