### PR TITLE
Implement plugin architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,7 @@ Pour consulter la documentation de l'API :
 3. Ouvrez votre navigateur à l'adresse [http://localhost:8000/swagger](http://localhost:8000/swagger).
 
 La documentation se base sur le fichier `public/swagger.yaml`.
+
+## Plugins
+
+See [docs/plugins.md](docs/plugins.md) for details on creating and registering modular plugins for both Laravel and Flutter.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,31 @@
+# Plugin System
+
+This project allows modules to be enabled or disabled dynamically using a `plugins.json` file for Laravel and the corresponding configuration in the Flutter app.
+
+## Laravel Plugins
+
+1. Define enabled modules in `laravel/plugins.json`:
+   ```json
+   {
+     "example": true
+   }
+   ```
+2. Each plugin lives inside `laravel/modules/<name>` with a `routes.php` file and optional `permissions.php` returning an array of permission strings.
+3. The `PluginServiceProvider` reads `plugins.json` and automatically loads routes and creates permissions for enabled plugins.
+4. The list of enabled plugins is exposed via the `/api/plugins` endpoint for the Flutter app.
+
+## Flutter Plugins
+
+1. Plugins register a route via `PluginRegistry.registerAvailable` in `lib/plugins`.
+2. At startup the app calls the API to obtain enabled plugins and activates them using `PluginRegistry.enablePlugins`.
+3. Enabled plugin routes are added to `MaterialApp.routes`.
+
+## Creating a New Plugin
+
+1. **Laravel**
+   - Create `laravel/modules/<your_plugin>/routes.php` and optionally `permissions.php`.
+   - Add the plugin name to `laravel/plugins.json` and set it to `true`.
+2. **Flutter**
+   - Create a Dart file under `flutterapp/lib/plugins` exporting a `register` function that calls `PluginRegistry.registerAvailable` with a `WidgetBuilder`.
+   - Import and invoke the register function in `main.dart`.
+3. Restart the backend and Flutter app. The plugin will be available when enabled in `plugins.json`.

--- a/flutterapp/lib/main.dart
+++ b/flutterapp/lib/main.dart
@@ -1,14 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'services/auth_service.dart';
+import 'services/api_service.dart';
 import 'screens/login_screen.dart';
 import 'screens/profile_screen.dart';
+import 'plugins/plugin_registry.dart';
+import 'plugins/example_plugin.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await dotenv.load(fileName: '.env');
+  registerExamplePlugin();
   final auth = AuthService();
   final token = await auth.getToken();
+  final api = ApiService();
+  final enabled = await api.getEnabledPlugins();
+  PluginRegistry.enablePlugins(enabled);
   runApp(MyApp(initialToken: token));
 }
 
@@ -23,6 +30,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
+      routes: PluginRegistry.routes,
       home: initialToken == null ? const LoginScreen() : const ProfileScreen(),
     );
   }

--- a/flutterapp/lib/plugins/example_plugin.dart
+++ b/flutterapp/lib/plugins/example_plugin.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'plugin_registry.dart';
+
+class ExampleScreen extends StatelessWidget {
+  const ExampleScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Example Plugin')),
+      body: const Center(child: Text('Example plugin screen')),
+    );
+  }
+}
+
+void registerExamplePlugin() {
+  PluginRegistry.registerAvailable(
+    const Plugin('example', (context) => ExampleScreen()),
+  );
+}

--- a/flutterapp/lib/plugins/plugin_registry.dart
+++ b/flutterapp/lib/plugins/plugin_registry.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/widgets.dart';
+
+class Plugin {
+  final String name;
+  final WidgetBuilder builder;
+  const Plugin(this.name, this.builder);
+}
+
+class PluginRegistry {
+  static final Map<String, Plugin> _available = {};
+  static final Map<String, Plugin> _enabled = {};
+
+  static void registerAvailable(Plugin plugin) {
+    _available[plugin.name] = plugin;
+  }
+
+  static void enablePlugins(Iterable<String> names) {
+    _enabled
+      ..clear();
+    for (final name in names) {
+      final plugin = _available[name];
+      if (plugin != null) {
+        _enabled[name] = plugin;
+      }
+    }
+  }
+
+  static Map<String, WidgetBuilder> get routes => {
+        for (final plugin in _enabled.values) '/${plugin.name}': plugin.builder,
+      };
+}

--- a/flutterapp/lib/services/api_service.dart
+++ b/flutterapp/lib/services/api_service.dart
@@ -37,4 +37,16 @@ class ApiService {
     }
     return null;
   }
+
+  Future<List<String>> getEnabledPlugins() async {
+    final response = await http.get(Uri.parse('$baseUrl/api/plugins'));
+    if (response.statusCode == 200) {
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      final list = data['plugins'];
+      if (list is List) {
+        return list.cast<String>();
+      }
+    }
+    return [];
+  }
 }

--- a/laravel/app/Providers/PluginServiceProvider.php
+++ b/laravel/app/Providers/PluginServiceProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\ServiceProvider;
+use Spatie\Permission\Models\Permission;
+
+class PluginServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $path = base_path('plugins.json');
+        if (!file_exists($path)) {
+            return;
+        }
+
+        $data = json_decode(file_get_contents($path), true);
+        if (!is_array($data)) {
+            return;
+        }
+
+        foreach ($data as $plugin => $enabled) {
+            if (!$enabled) {
+                continue;
+            }
+
+            $routeFile = base_path("modules/{$plugin}/routes.php");
+            if (file_exists($routeFile)) {
+                Route::middleware('web')->group($routeFile);
+            }
+
+            $permFile = base_path("modules/{$plugin}/permissions.php");
+            if (file_exists($permFile)) {
+                $permissions = require $permFile;
+                if (is_array($permissions)) {
+                    foreach ($permissions as $permission) {
+                        Permission::findOrCreate($permission);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/laravel/bootstrap/providers.php
+++ b/laravel/bootstrap/providers.php
@@ -2,4 +2,5 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    App\Providers\PluginServiceProvider::class,
 ];

--- a/laravel/modules/example/permissions.php
+++ b/laravel/modules/example/permissions.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'view example',
+];

--- a/laravel/modules/example/routes.php
+++ b/laravel/modules/example/routes.php
@@ -1,0 +1,7 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/example', function () {
+    return 'Example plugin route';
+});

--- a/laravel/plugins.json
+++ b/laravel/plugins.json
@@ -1,0 +1,3 @@
+{
+    "example": true
+}

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/plugins', function () {
+    $path = base_path('plugins.json');
+    $enabled = [];
+    if (file_exists($path)) {
+        $data = json_decode(file_get_contents($path), true);
+        if (is_array($data)) {
+            $enabled = array_keys(array_filter($data));
+        }
+    }
+    return ['plugins' => $enabled];
+});


### PR DESCRIPTION
## Summary
- support modular plugins in Laravel via PluginServiceProvider
- expose enabled plugins through `/api/plugins`
- register plugins dynamically in Flutter
- add example plugin and registry
- document how to add plugins

## Testing
- `composer test` *(fails: composer not installed)*
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686b185678b0832f9fdc68d6e7d436f8