### PR TITLE
Add translation API and dynamic Flutter localization

### DIFF
--- a/flutterapp/lib/main.dart
+++ b/flutterapp/lib/main.dart
@@ -1,15 +1,26 @@
 import 'package:flutter/material.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'services/auth_service.dart';
+import 'services/translation_service.dart';
 import 'screens/login_screen.dart';
 import 'screens/profile_screen.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await EasyLocalization.ensureInitialized();
   await dotenv.load(fileName: '.env');
   final auth = AuthService();
   final token = await auth.getToken();
-  runApp(MyApp(initialToken: token));
+  runApp(
+    EasyLocalization(
+      supportedLocales: const [Locale('en'), Locale('fr')],
+      fallbackLocale: const Locale('en'),
+      path: '',
+      assetLoader: ApiAssetLoader(),
+      child: MyApp(initialToken: token),
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {
@@ -23,6 +34,9 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
+      localizationsDelegates: context.localizationDelegates,
+      supportedLocales: context.supportedLocales,
+      locale: context.locale,
       home: initialToken == null ? const LoginScreen() : const ProfileScreen(),
     );
   }

--- a/flutterapp/lib/screens/login_screen.dart
+++ b/flutterapp/lib/screens/login_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:easy_localization/easy_localization.dart';
 import '../services/api_service.dart';
 import '../services/auth_service.dart';
 import 'profile_screen.dart';
@@ -36,14 +37,14 @@ class _LoginScreenState extends State<LoginScreen> {
       );
     } else {
       ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Login failed')));
+          .showSnackBar(SnackBar(content: Text('login_failed'.tr())));
     }
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Login')),
+      appBar: AppBar(title: Text('login'.tr())),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Form(
@@ -52,19 +53,19 @@ class _LoginScreenState extends State<LoginScreen> {
             children: [
               TextFormField(
                 controller: _emailController,
-                decoration: const InputDecoration(labelText: 'Email'),
-                validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+                decoration: InputDecoration(labelText: 'email'.tr()),
+                validator: (v) => v == null || v.isEmpty ? 'required'.tr() : null,
               ),
               TextFormField(
                 controller: _passwordController,
-                decoration: const InputDecoration(labelText: 'Password'),
+                decoration: InputDecoration(labelText: 'password'.tr()),
                 obscureText: true,
-                validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+                validator: (v) => v == null || v.isEmpty ? 'required'.tr() : null,
               ),
               const SizedBox(height: 16),
               ElevatedButton(
                 onPressed: _isLoading ? null : _submit,
-                child: const Text('Login'),
+                child: Text('login'.tr()),
               ),
               TextButton(
                 onPressed: () {
@@ -73,7 +74,7 @@ class _LoginScreenState extends State<LoginScreen> {
                         builder: (_) => const RegistrationScreen()),
                   );
                 },
-                child: const Text('Register'),
+                child: Text('register'.tr()),
               )
             ],
           ),

--- a/flutterapp/lib/screens/profile_screen.dart
+++ b/flutterapp/lib/screens/profile_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:easy_localization/easy_localization.dart';
 import '../services/api_service.dart';
 import '../services/auth_service.dart';
 import 'login_screen.dart';
@@ -40,7 +41,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Profile'),
+        title: Text('profile'.tr()),
         actions: [
           IconButton(onPressed: _logout, icon: const Icon(Icons.logout))
         ],
@@ -48,7 +49,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
       body: Center(
         child: _profile == null
             ? const CircularProgressIndicator()
-            : Text('Hello ${_profile!['name'] ?? ''}'),
+            : Text(tr('hello_name', namedArgs: {'name': _profile!['name'] ?? ''})),
       ),
     );
   }

--- a/flutterapp/lib/screens/registration_screen.dart
+++ b/flutterapp/lib/screens/registration_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:easy_localization/easy_localization.dart';
 import '../services/api_service.dart';
 
 class RegistrationScreen extends StatefulWidget {
@@ -31,14 +32,14 @@ class _RegistrationScreenState extends State<RegistrationScreen> {
       Navigator.of(context).pop();
     } else {
       ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Registration failed')));
+          .showSnackBar(SnackBar(content: Text('registration_failed'.tr())));
     }
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Register')),
+      appBar: AppBar(title: Text('register'.tr())),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Form(
@@ -47,24 +48,24 @@ class _RegistrationScreenState extends State<RegistrationScreen> {
             children: [
               TextFormField(
                 controller: _nameController,
-                decoration: const InputDecoration(labelText: 'Name'),
-                validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+                decoration: InputDecoration(labelText: 'name'.tr()),
+                validator: (v) => v == null || v.isEmpty ? 'required'.tr() : null,
               ),
               TextFormField(
                 controller: _emailController,
-                decoration: const InputDecoration(labelText: 'Email'),
-                validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+                decoration: InputDecoration(labelText: 'email'.tr()),
+                validator: (v) => v == null || v.isEmpty ? 'required'.tr() : null,
               ),
               TextFormField(
                 controller: _passwordController,
-                decoration: const InputDecoration(labelText: 'Password'),
+                decoration: InputDecoration(labelText: 'password'.tr()),
                 obscureText: true,
-                validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+                validator: (v) => v == null || v.isEmpty ? 'required'.tr() : null,
               ),
               const SizedBox(height: 16),
               ElevatedButton(
                 onPressed: _loading ? null : _submit,
-                child: const Text('Register'),
+                child: Text('register'.tr()),
               ),
             ],
           ),

--- a/flutterapp/lib/services/translation_service.dart
+++ b/flutterapp/lib/services/translation_service.dart
@@ -1,0 +1,19 @@
+import 'dart:convert';
+import 'package:easy_localization/easy_localization.dart';
+import 'dart:ui';
+import 'package:http/http.dart' as http;
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+class ApiAssetLoader extends AssetLoader {
+  final String baseUrl = dotenv.env['API_BASE_URL'] ?? '';
+
+  @override
+  Future<Map<String, dynamic>> load(String path, Locale locale) async {
+    final response = await http
+        .get(Uri.parse('$baseUrl/api/translations/${locale.languageCode}'));
+    if (response.statusCode == 200) {
+      return jsonDecode(response.body) as Map<String, dynamic>;
+    }
+    return {};
+  }
+}

--- a/flutterapp/pubspec.yaml
+++ b/flutterapp/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   http: ^1.1.0
   flutter_dotenv: ^5.0.2
   shared_preferences: ^2.2.2
+  easy_localization: ^3.0.2
 
 dev_dependencies:
   flutter_test:

--- a/flutterapp/test/login_validation_test.dart
+++ b/flutterapp/test/login_validation_test.dart
@@ -1,10 +1,26 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutterapp/screens/login_screen.dart';
+import 'test_asset_loader.dart';
 
 void main() {
   testWidgets('Login button disabled when fields empty', (WidgetTester tester) async {
-    await tester.pumpWidget(const MaterialApp(home: LoginScreen()));
+    await tester.pumpWidget(
+      EasyLocalization(
+        supportedLocales: const [Locale('en')],
+        path: '',
+        assetLoader: const TestAssetLoader({
+          'login': 'Login',
+          'email': 'Email',
+          'password': 'Password',
+          'required': 'Required',
+          'register': 'Register'
+        }),
+        child: const MaterialApp(home: LoginScreen()),
+      ),
+    );
+    await tester.pump();
     final ElevatedButton button = tester.widget(find.widgetWithText(ElevatedButton, 'Login'));
     expect(button.onPressed, isNull);
 

--- a/flutterapp/test/test_asset_loader.dart
+++ b/flutterapp/test/test_asset_loader.dart
@@ -1,0 +1,12 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'dart:ui';
+
+class TestAssetLoader extends AssetLoader {
+  final Map<String, dynamic> data;
+  const TestAssetLoader(this.data);
+
+  @override
+  Future<Map<String, dynamic>> load(String path, Locale locale) async {
+    return data;
+  }
+}

--- a/flutterapp/test/widget_test.dart
+++ b/flutterapp/test/widget_test.dart
@@ -1,10 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutterapp/main.dart';
+import 'test_asset_loader.dart';
 
 void main() {
   testWidgets('Shows login screen', (WidgetTester tester) async {
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(
+      EasyLocalization(
+        supportedLocales: const [Locale('en')],
+        path: '',
+        assetLoader: const TestAssetLoader({'login': 'Login'}),
+        child: const MyApp(),
+      ),
+    );
+    await tester.pump();
     expect(find.text('Login'), findsOneWidget);
   });
 }

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/laravel/lang/en/messages.php
+++ b/laravel/lang/en/messages.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'login' => 'Login',
+    'register' => 'Register',
+    'email' => 'Email',
+    'password' => 'Password',
+    'name' => 'Name',
+    'required' => 'Required',
+    'profile' => 'Profile',
+    'logout' => 'Log Out',
+    'login_failed' => 'Login failed',
+    'registration_failed' => 'Registration failed',
+    'hello_name' => 'Hello :name',
+];

--- a/laravel/lang/fr/messages.php
+++ b/laravel/lang/fr/messages.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'login' => 'Connexion',
+    'register' => 'Inscription',
+    'email' => 'E-mail',
+    'password' => 'Mot de passe',
+    'name' => 'Nom',
+    'required' => 'Requis',
+    'profile' => 'Profil',
+    'logout' => 'Déconnexion',
+    'login_failed' => 'Échec de la connexion',
+    'registration_failed' => "Échec de l'inscription",
+    'hello_name' => 'Bonjour :name',
+];

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,0 +1,14 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/translations/{locale}', function (string $locale) {
+    $path = lang_path("$locale/messages.php");
+
+    if (!File::exists($path)) {
+        abort(404);
+    }
+
+    return response()->json(require $path);
+});


### PR DESCRIPTION
## Summary
- create language files in Laravel
- expose `/api/translations/{locale}` route
- load api routes in `bootstrap/app.php`
- integrate easy_localization in Flutter
- dynamically fetch translations from backend
- adapt screens and tests to translated strings

## Testing
- `php artisan test` *(fails: php not found)*
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b185e3dbc832f88b4c97955dd2330