### PR TITLE
Add analytics tracking

### DIFF
--- a/flutterapp/lib/screens/login_screen.dart
+++ b/flutterapp/lib/screens/login_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../services/api_service.dart';
 import '../services/auth_service.dart';
+import '../services/analytics_service.dart';
 import 'profile_screen.dart';
 import 'registration_screen.dart';
 
@@ -19,6 +20,13 @@ class _LoginScreenState extends State<LoginScreen> {
 
   final ApiService _api = ApiService();
   final AuthService _auth = AuthService();
+  final AnalyticsService _analytics = AnalyticsService();
+
+  @override
+  void initState() {
+    super.initState();
+    _analytics.trackPage('login');
+  }
 
   Future<void> _submit() async {
     if (!_formKey.currentState!.validate()) return;

--- a/flutterapp/lib/screens/profile_screen.dart
+++ b/flutterapp/lib/screens/profile_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../services/api_service.dart';
 import '../services/auth_service.dart';
+import '../services/analytics_service.dart';
 import 'login_screen.dart';
 
 class ProfileScreen extends StatefulWidget {
@@ -13,11 +14,13 @@ class ProfileScreen extends StatefulWidget {
 class _ProfileScreenState extends State<ProfileScreen> {
   final ApiService _api = ApiService();
   final AuthService _auth = AuthService();
+  final AnalyticsService _analytics = AnalyticsService();
   Map<String, dynamic>? _profile;
 
   @override
   void initState() {
     super.initState();
+    _analytics.trackPage('profile');
     _loadProfile();
   }
 

--- a/flutterapp/lib/screens/registration_screen.dart
+++ b/flutterapp/lib/screens/registration_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../services/api_service.dart';
+import '../services/analytics_service.dart';
 
 class RegistrationScreen extends StatefulWidget {
   const RegistrationScreen({super.key});
@@ -16,6 +17,13 @@ class _RegistrationScreenState extends State<RegistrationScreen> {
   bool _loading = false;
 
   final ApiService _api = ApiService();
+  final AnalyticsService _analytics = AnalyticsService();
+
+  @override
+  void initState() {
+    super.initState();
+    _analytics.trackPage('register');
+  }
 
   Future<void> _submit() async {
     if (!_formKey.currentState!.validate()) return;

--- a/flutterapp/lib/services/analytics_service.dart
+++ b/flutterapp/lib/services/analytics_service.dart
@@ -1,0 +1,21 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'auth_service.dart';
+
+class AnalyticsService {
+  final String baseUrl = dotenv.env['API_BASE_URL'] ?? '';
+  final AuthService _auth = AuthService();
+
+  Future<void> trackPage(String page) async {
+    final token = await _auth.getToken();
+    await http.post(
+      Uri.parse('$baseUrl/api/analytics'),
+      headers: {
+        'Content-Type': 'application/json',
+        if (token != null) 'Authorization': 'Bearer $token',
+      },
+      body: jsonEncode({'page': page}),
+    );
+  }
+}

--- a/laravel/app/Http/Middleware/RecordPageView.php
+++ b/laravel/app/Http/Middleware/RecordPageView.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Analytics;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RecordPageView
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        try {
+            Analytics::create([
+                'page' => $request->path(),
+                'user_id' => $request->user()?->id,
+            ]);
+        } catch (\Throwable $e) {
+            // Logging can be added here if needed
+        }
+
+        return $response;
+    }
+}

--- a/laravel/app/Models/Analytics.php
+++ b/laravel/app/Models/Analytics.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Analytics extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'page',
+        'user_id',
+    ];
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -11,7 +11,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->append(\App\Http\Middleware\RecordPageView::class);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/laravel/database/migrations/2025_07_07_000000_create_analytics_table.php
+++ b/laravel/database/migrations/2025_07_07_000000_create_analytics_table.php
@@ -1,0 +1,22 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('analytics', function (Blueprint $table) {
+            $table->id();
+            $table->string('page');
+            $table->foreignId('user_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('analytics');
+    }
+};

--- a/laravel/resources/views/analytics/index.blade.php
+++ b/laravel/resources/views/analytics/index.blade.php
@@ -1,0 +1,31 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 dark:text-gray-100">
+                    <h2 class="text-xl font-bold mb-4">Analytics</h2>
+                    <table class="min-w-full text-sm">
+                        <thead>
+                            <tr>
+                                <th class="px-4 py-2 text-left">Page</th>
+                                <th class="px-4 py-2 text-left">User ID</th>
+                                <th class="px-4 py-2 text-left">Timestamp</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach($analytics as $entry)
+                                <tr>
+                                    <td class="border px-4 py-2">{{ $entry->page }}</td>
+                                    <td class="border px-4 py-2">{{ $entry->user_id ?? 'guest' }}</td>
+                                    <td class="border px-4 py-2">{{ $entry->created_at }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -18,3 +18,17 @@ Route::middleware('auth')->group(function () {
 });
 
 require __DIR__.'/auth.php';
+
+Route::post('/api/analytics', function (\Illuminate\Http\Request $request) {
+    \App\Models\Analytics::create([
+        'page' => $request->input('page', $request->path()),
+        'user_id' => $request->user()?->id,
+    ]);
+
+    return response()->noContent();
+})->name('analytics.store');
+
+Route::get('/analytics', function () {
+    $analytics = \App\Models\Analytics::latest()->paginate(50);
+    return view('analytics.index', compact('analytics'));
+})->middleware(['auth', 'verified'])->name('analytics.index');


### PR DESCRIPTION
## Summary
- add Analytics Eloquent model and migration
- record page views with new middleware
- expose routes to store and display analytics
- add Flutter analytics service
- track important screens in Flutter

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686b185eba38832fb90510e0417bbf68