### PR TITLE
Add CMS block API and Flutter service

### DIFF
--- a/flutterapp/lib/screens/profile_screen.dart
+++ b/flutterapp/lib/screens/profile_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../services/api_service.dart';
 import '../services/auth_service.dart';
+import '../services/cms_block_service.dart';
 import 'login_screen.dart';
 
 class ProfileScreen extends StatefulWidget {
@@ -13,12 +14,15 @@ class ProfileScreen extends StatefulWidget {
 class _ProfileScreenState extends State<ProfileScreen> {
   final ApiService _api = ApiService();
   final AuthService _auth = AuthService();
+  final CMSBlockService _cms = CMSBlockService();
   Map<String, dynamic>? _profile;
+  String? _block;
 
   @override
   void initState() {
     super.initState();
     _loadProfile();
+    _loadBlock();
   }
 
   Future<void> _loadProfile() async {
@@ -26,6 +30,11 @@ class _ProfileScreenState extends State<ProfileScreen> {
     if (token == null) return;
     final data = await _api.getProfile(token);
     setState(() => _profile = data);
+  }
+
+  Future<void> _loadBlock() async {
+    final value = await _cms.get('welcome');
+    setState(() => _block = value);
   }
 
   Future<void> _logout() async {
@@ -48,7 +57,13 @@ class _ProfileScreenState extends State<ProfileScreen> {
       body: Center(
         child: _profile == null
             ? const CircularProgressIndicator()
-            : Text('Hello ${_profile!['name'] ?? ''}'),
+            : Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text('Hello ${_profile!['name'] ?? ''}'),
+                  if (_block != null) Text(_block!),
+                ],
+              ),
       ),
     );
   }

--- a/flutterapp/lib/services/cms_block_service.dart
+++ b/flutterapp/lib/services/cms_block_service.dart
@@ -1,0 +1,16 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+class CMSBlockService {
+  final String baseUrl = dotenv.env['API_BASE_URL'] ?? '';
+
+  Future<String?> get(String key) async {
+    final response = await http.get(Uri.parse('$baseUrl/api/blocks/$key'));
+    if (response.statusCode == 200) {
+      final data = jsonDecode(response.body);
+      return data['value'] as String?;
+    }
+    return null;
+  }
+}

--- a/flutterapp/test/cms_block_service_test.dart
+++ b/flutterapp/test/cms_block_service_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutterapp/services/cms_block_service.dart';
+
+void main() {
+  test('Base URL loaded from env', () {
+    dotenv.testLoad(fileInput: 'API_BASE_URL=http://test');
+    final service = CMSBlockService();
+    expect(service.baseUrl, 'http://test');
+  });
+}

--- a/laravel/app/Http/Controllers/CmsBlockController.php
+++ b/laravel/app/Http/Controllers/CmsBlockController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\CmsBlock;
+use Illuminate\Http\JsonResponse;
+
+class CmsBlockController extends Controller
+{
+    public function show(string $key): JsonResponse
+    {
+        $block = CmsBlock::where('key', $key)->firstOrFail();
+        return response()->json($block);
+    }
+}

--- a/laravel/app/Models/CmsBlock.php
+++ b/laravel/app/Models/CmsBlock.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CmsBlock extends Model
+{
+    protected $fillable = ['key', 'type', 'value'];
+}

--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/laravel/database/migrations/2025_07_07_000000_create_cms_blocks_table.php
+++ b/laravel/database/migrations/2025_07_07_000000_create_cms_blocks_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cms_blocks', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->string('type');
+            $table->text('value');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cms_blocks');
+    }
+};

--- a/laravel/public/swagger.yaml
+++ b/laravel/public/swagger.yaml
@@ -81,9 +81,27 @@ paths:
       responses:
         '204':
           description: Account deleted
-components:
-  securitySchemes:
-    BearerAuth:
+  /blocks/{key}:
+    get:
+      summary: Fetch CMS block by key
+      parameters:
+        - in: path
+          name: key
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Block details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CmsBlock'
+        '404':
+          description: Block not found
+  components:
+    securitySchemes:
+      BearerAuth:
       type: http
       scheme: bearer
       bearerFormat: JWT
@@ -144,10 +162,27 @@ components:
         updated_at:
           type: string
           format: date-time
-    AuthToken:
-      type: object
-      properties:
-        token:
-          type: string
-        user:
-          $ref: '#/components/schemas/User'
+  AuthToken:
+    type: object
+    properties:
+      token:
+        type: string
+      user:
+        $ref: '#/components/schemas/User'
+  CmsBlock:
+    type: object
+    properties:
+      id:
+        type: integer
+      key:
+        type: string
+      type:
+        type: string
+      value:
+        type: string
+      created_at:
+        type: string
+        format: date-time
+      updated_at:
+        type: string
+        format: date-time

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,0 +1,6 @@
+<?php
+
+use App\Http\Controllers\CmsBlockController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/blocks/{key}', [CmsBlockController::class, 'show']);

--- a/laravel/tests/Feature/CmsBlockTest.php
+++ b/laravel/tests/Feature/CmsBlockTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use App\Models\CmsBlock;
+
+it('returns block by key', function () {
+    CmsBlock::create([
+        'key' => 'welcome',
+        'type' => 'text',
+        'value' => 'Hello world',
+    ]);
+
+    $response = $this->getJson('/api/blocks/welcome');
+
+    $response->assertOk();
+    $response->assertJson([
+        'key' => 'welcome',
+        'type' => 'text',
+        'value' => 'Hello world',
+    ]);
+});


### PR DESCRIPTION
## Summary
- create `cms_blocks` table and model
- expose `/api/blocks/{key}` endpoint
- document CMS block endpoint in Swagger
- show CMS block on profile screen
- implement `CMSBlockService` with test
- add backend feature test

## Testing
- `php artisan test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b185f36e8832f809e79421197ff2c