### PR TITLE
Update variable name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ flutter pub get
 The mobile app can receive the API base URL using a dart define:
 
 ```bash
-flutter run --dart-define=API_URL=http://localhost:8000
+flutter run --dart-define=API_BASE_URL=http://localhost:8000
 ```
 
 In Laravel, configure `APP_URL` and your database credentials in `.env`.


### PR DESCRIPTION
## Summary
- rename `API_URL` to `API_BASE_URL` in the Flutter run command

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b1fd23378832fa04eb1156c9afce8