### PR TITLE
Fix registration API test structure

### DIFF
--- a/laravel/tests/Feature/AuthApiTest.php
+++ b/laravel/tests/Feature/AuthApiTest.php
@@ -15,11 +15,14 @@ it('registers a user via the API', function () {
     $response = $this->postJson('/api/register', $payload);
 
     $response->assertCreated()->assertJsonStructure([
-        'id',
-        'name',
-        'email',
-        'created_at',
-        'updated_at',
+        'token',
+        'user' => [
+            'id',
+            'name',
+            'email',
+            'created_at',
+            'updated_at',
+        ],
     ]);
 
     expect(User::where('email', 'john@example.com')->exists())->toBeTrue();


### PR DESCRIPTION
## Summary
- update registration test JSON expectation to include token and nested user object

## Testing
- `php artisan test --testsuite Feature` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686b1fd36fac832f8a0f77291b3149fd