### PR TITLE
Add dynamic forms feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ flutter run --dart-define=API_URL=http://localhost:8000
 ```
 
 In Laravel, configure `APP_URL` and your database credentials in `.env`.
+## Dynamic Forms
+
+Use the `/api/forms` endpoints to create and manage forms and their fields. After migrating the database, authenticated requests can create forms and fields.
+
+In Flutter, use the `DynamicFormBuilder` widget to render a list of fields and handle submission.
 
 ## Swagger UI
 

--- a/flutterapp/lib/dynamic_form_builder.dart
+++ b/flutterapp/lib/dynamic_form_builder.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+class DynamicFormBuilder extends StatefulWidget {
+  final List<Map<String, dynamic>> fields;
+  final void Function(Map<String, dynamic> values) onSubmit;
+
+  const DynamicFormBuilder({
+    Key? key,
+    required this.fields,
+    required this.onSubmit,
+  }) : super(key: key);
+
+  @override
+  State<DynamicFormBuilder> createState() => _DynamicFormBuilderState();
+}
+
+class _DynamicFormBuilderState extends State<DynamicFormBuilder> {
+  final _formKey = GlobalKey<FormState>();
+  final Map<String, dynamic> _values = {};
+
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      key: _formKey,
+      child: Column(
+        children: [
+          ...widget.fields.map((field) {
+            final label = field['label'] as String? ?? '';
+            final type = field['type'] as String? ?? 'text';
+            final requiredField = field['required'] == true;
+            if (type == 'checkbox') {
+              _values[label] = _values[label] ?? false;
+              return CheckboxListTile(
+                title: Text(label),
+                value: _values[label] as bool,
+                onChanged: (v) => setState(() => _values[label] = v),
+              );
+            }
+            return TextFormField(
+              decoration: InputDecoration(labelText: label),
+              keyboardType: type == 'number' ? TextInputType.number : null,
+              validator: requiredField
+                  ? (v) => v == null || v.isEmpty ? 'Required' : null
+                  : null,
+              onSaved: (v) => _values[label] = v,
+            );
+          }),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () {
+              if (_formKey.currentState!.validate()) {
+                _formKey.currentState!.save();
+                widget.onSubmit(_values);
+              }
+            },
+            child: const Text('Submit'),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/laravel/app/Http/Controllers/API/FormController.php
+++ b/laravel/app/Http/Controllers/API/FormController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Models\Form;
+use Illuminate\Http\Request;
+
+class FormController extends Controller
+{
+    public function index()
+    {
+        return Form::with('fields')->get();
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+        ]);
+
+        $form = Form::create($data);
+
+        return response()->json($form, 201);
+    }
+
+    public function show(Form $form)
+    {
+        return $form->load('fields');
+    }
+
+    public function update(Request $request, Form $form)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+        ]);
+
+        $form->update($data);
+
+        return response()->json($form);
+    }
+
+    public function destroy(Form $form)
+    {
+        $form->delete();
+
+        return response()->json(null, 204);
+    }
+}

--- a/laravel/app/Http/Controllers/API/FormFieldController.php
+++ b/laravel/app/Http/Controllers/API/FormFieldController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Models\Form;
+use App\Models\FormField;
+use Illuminate\Http\Request;
+
+class FormFieldController extends Controller
+{
+    public function index(Form $form)
+    {
+        return $form->fields;
+    }
+
+    public function store(Request $request, Form $form)
+    {
+        $data = $request->validate([
+            'label' => 'required|string|max:255',
+            'type' => 'required|string|max:50',
+            'required' => 'boolean',
+        ]);
+
+        $field = $form->fields()->create($data);
+
+        return response()->json($field, 201);
+    }
+
+    public function show(FormField $field)
+    {
+        return $field;
+    }
+
+    public function update(Request $request, FormField $field)
+    {
+        $data = $request->validate([
+            'label' => 'sometimes|required|string|max:255',
+            'type' => 'sometimes|required|string|max:50',
+            'required' => 'boolean',
+        ]);
+
+        $field->update($data);
+
+        return response()->json($field);
+    }
+
+    public function destroy(FormField $field)
+    {
+        $field->delete();
+
+        return response()->json(null, 204);
+    }
+}

--- a/laravel/app/Models/Form.php
+++ b/laravel/app/Models/Form.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Form extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+    ];
+
+    public function fields()
+    {
+        return $this->hasMany(FormField::class);
+    }
+}

--- a/laravel/app/Models/FormField.php
+++ b/laravel/app/Models/FormField.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class FormField extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'form_id',
+        'label',
+        'type',
+        'required',
+    ];
+
+    protected $casts = [
+        'required' => 'boolean',
+    ];
+
+    public function form()
+    {
+        return $this->belongsTo(Form::class);
+    }
+}

--- a/laravel/database/migrations/2025_07_07_000000_create_forms_table.php
+++ b/laravel/database/migrations/2025_07_07_000000_create_forms_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('forms', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('forms');
+    }
+};

--- a/laravel/database/migrations/2025_07_07_000001_create_form_fields_table.php
+++ b/laravel/database/migrations/2025_07_07_000001_create_form_fields_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('form_fields', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('form_id')->constrained()->cascadeOnDelete();
+            $table->string('label');
+            $table->string('type');
+            $table->boolean('required')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('form_fields');
+    }
+};

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Http\Requests\Auth\LoginRequest;
+use App\Http\Controllers\API\FormController;
+use App\Http\Controllers\API\FormFieldController;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Http\Request;
@@ -17,7 +19,7 @@ Route::post('/login', function (LoginRequest $request) {
 Route::post('/register', function (Request $request) {
     $attributes = $request->validate([
         'name' => ['required', 'string', 'max:255'],
-        'email' => ['required', 'string', 'email', 'max:255', 'unique:'.User::class],
+        'email' => ['required', 'string', 'email', 'max:255', 'unique:' . User::class],
         'password' => ['required', 'string', 'confirmed'],
     ]);
 
@@ -32,10 +34,16 @@ Route::post('/register', function (Request $request) {
     return response()->json(['token' => $token, 'user' => $user], 201);
 });
 
-Route::middleware('auth:sanctum')->get('/profile', function (Request $request) {
-    return response()->json(['user' => $request->user()]);
-});
+Route::middleware('auth:sanctum')->group(function () {
+    Route::get('/profile', function (Request $request) {
+        return response()->json(['user' => $request->user()]);
+    });
 
-Route::middleware('auth:sanctum')->post('/logout', function (Request $request) {
-    $request->user()->currentAccessToken()->delete();
-    return response()->json([], 204);
+    Route::post('/logout', function (Request $request) {
+        $request->user()->currentAccessToken()->delete();
+        return response()->json([], 204);
+    });
+
+    Route::apiResource('forms', FormController::class);
+    Route::apiResource('forms.fields', FormFieldController::class)->shallow();
+});


### PR DESCRIPTION
## Summary
- add Form and FormField models with migrations
- implement API controllers and routes for forms
- add a Flutter `DynamicFormBuilder` widget
- document dynamic forms usage

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686b1fd42fe0832fa67534b68780b1e4