### PR TITLE
Implement user settings backend and Flutter integration

### DIFF
--- a/flutterapp/lib/main.dart
+++ b/flutterapp/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'services/secure_auth_service.dart';
+import 'services/settings_service.dart';
 import 'screens/login_screen.dart';
 import 'screens/profile_screen.dart';
 
@@ -12,18 +13,46 @@ Future<void> main() async {
   runApp(MyApp(initialToken: token));
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   final String? initialToken;
   const MyApp({super.key, this.initialToken});
 
   @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  bool _darkMode = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSettings();
+  }
+
+  Future<void> _loadSettings() async {
+    final service = SettingsService();
+    final settings = await service.loadSettings();
+    setState(() {
+      _darkMode = settings['darkMode'] == 'true' || settings['darkMode'] == true;
+    });
+  }
+
+  void _updateTheme(bool dark) {
+    setState(() {
+      _darkMode = dark;
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final theme = _darkMode ? ThemeData.dark() : ThemeData.light();
     return MaterialApp(
       title: 'Flutter Demo',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: initialToken == null ? const LoginScreen() : const ProfileScreen(),
+      theme: theme,
+      home: widget.initialToken == null
+          ? LoginScreen(onThemeChanged: _updateTheme)
+          : ProfileScreen(onThemeChanged: _updateTheme),
     );
   }
 }

--- a/flutterapp/lib/screens/login_screen.dart
+++ b/flutterapp/lib/screens/login_screen.dart
@@ -5,7 +5,8 @@ import 'profile_screen.dart';
 import 'registration_screen.dart';
 
 class LoginScreen extends StatefulWidget {
-  const LoginScreen({super.key});
+  final void Function(bool)? onThemeChanged;
+  const LoginScreen({super.key, this.onThemeChanged});
 
   @override
   State<LoginScreen> createState() => _LoginScreenState();
@@ -32,7 +33,8 @@ class _LoginScreenState extends State<LoginScreen> {
       await _auth.saveToken(token);
       if (!mounted) return;
       Navigator.of(context).pushReplacement(
-        MaterialPageRoute(builder: (_) => const ProfileScreen()),
+        MaterialPageRoute(
+            builder: (_) => ProfileScreen(onThemeChanged: widget.onThemeChanged)),
       );
     } else {
       ScaffoldMessenger.of(context)

--- a/flutterapp/lib/services/api_service.dart
+++ b/flutterapp/lib/services/api_service.dart
@@ -37,4 +37,26 @@ class ApiService {
     }
     return null;
   }
+
+  Future<Map<String, dynamic>?> getSettings(String token) async {
+    final response = await http.get(
+      Uri.parse('$baseUrl/api/settings'),
+      headers: {'Authorization': 'Bearer $token'},
+    );
+    if (response.statusCode == 200) {
+      return jsonDecode(response.body) as Map<String, dynamic>;
+    }
+    return null;
+  }
+
+  Future<void> updateSetting(String token, String key, dynamic value) async {
+    await http.put(
+      Uri.parse('$baseUrl/api/settings/$key'),
+      headers: {
+        'Authorization': 'Bearer $token',
+        'Content-Type': 'application/json'
+      },
+      body: jsonEncode({'value': value.toString()}),
+    );
+  }
 }

--- a/flutterapp/lib/services/settings_service.dart
+++ b/flutterapp/lib/services/settings_service.dart
@@ -1,0 +1,20 @@
+import 'api_service.dart';
+import 'secure_auth_service.dart';
+
+class SettingsService {
+  final ApiService _api = ApiService();
+  final SecureAuthService _auth = SecureAuthService();
+
+  Future<Map<String, dynamic>> loadSettings() async {
+    final token = await _auth.getToken();
+    if (token == null) return {};
+    final data = await _api.getSettings(token);
+    return data ?? {};
+  }
+
+  Future<void> updateSetting(String key, dynamic value) async {
+    final token = await _auth.getToken();
+    if (token == null) return;
+    await _api.updateSetting(token, key, value);
+  }
+}

--- a/laravel/app/Http/Controllers/API/SettingController.php
+++ b/laravel/app/Http/Controllers/API/SettingController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Models\UserSetting;
+use Illuminate\Http\Request;
+
+class SettingController extends Controller
+{
+    public function index(Request $request)
+    {
+        $settings = $request->user()->settings()->pluck('value', 'key');
+        return response()->json($settings);
+    }
+
+    public function update(Request $request, string $key)
+    {
+        $request->validate(['value' => ['nullable', 'string']]);
+        $setting = UserSetting::updateOrCreate(
+            ['user_id' => $request->user()->id, 'key' => $key],
+            ['value' => $request->input('value')]
+        );
+        return response()->json($setting);
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 use Spatie\Permission\Traits\HasRoles;
+use App\Models\UserSetting;
 
 
 class User extends Authenticatable
@@ -48,5 +49,13 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    /**
+     * Get the user's settings.
+     */
+    public function settings()
+    {
+        return $this->hasMany(UserSetting::class);
     }
 }

--- a/laravel/app/Models/UserSetting.php
+++ b/laravel/app/Models/UserSetting.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class UserSetting extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['user_id', 'key', 'value'];
+}

--- a/laravel/database/migrations/2025_07_07_000000_create_user_settings_table.php
+++ b/laravel/database/migrations/2025_07_07_000000_create_user_settings_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('user_settings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('key');
+            $table->text('value')->nullable();
+            $table->timestamps();
+            $table->unique(['user_id', 'key']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('user_settings');
+    }
+};

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,41 +1,16 @@
 <?php
 
-use App\Http\Requests\Auth\LoginRequest;
-use App\Models\User;
-use Illuminate\Support\Facades\Hash;
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\API\AuthController;
+use App\Http\Controllers\API\ProfileController;
+use App\Http\Controllers\API\SettingController;
 
-Route::post('/login', function (LoginRequest $request) {
-    $request->authenticate();
-    $user = $request->user();
-    $token = $user->createToken('api-token')->plainTextToken;
-    return response()->json(['token' => $token, 'user' => $user]);
+Route::post('/register', [AuthController::class, 'register']);
+Route::post('/login', [AuthController::class, 'login']);
+
+Route::middleware('auth:sanctum')->group(function () {
+    Route::get('/profile', [ProfileController::class, 'show']);
+    Route::post('/logout', [AuthController::class, 'logout']);
+    Route::get('/settings', [SettingController::class, 'index']);
+    Route::put('/settings/{key}', [SettingController::class, 'update']);
 });
-
-Route::post('/register', function (Request $request) {
-    $attributes = $request->validate([
-        'name' => ['required', 'string', 'max:255'],
-        'email' => ['required', 'string', 'email', 'max:255', 'unique:'.User::class],
-        'password' => ['required', 'string', 'confirmed'],
-    ]);
-
-    $user = User::create([
-        'name' => $attributes['name'],
-        'email' => $attributes['email'],
-        'password' => Hash::make($attributes['password']),
-    ]);
-
-    $token = $user->createToken('api-token')->plainTextToken;
-
-    return response()->json(['token' => $token, 'user' => $user], 201);
-});
-
-Route::middleware('auth:sanctum')->get('/profile', function (Request $request) {
-    return response()->json(['user' => $request->user()]);
-});
-
-Route::middleware('auth:sanctum')->post('/logout', function (Request $request) {
-    $request->user()->currentAccessToken()->delete();
-    return response()->json([], 204);


### PR DESCRIPTION
## Summary
- add `user_settings` migration, model, controller and routes in Laravel
- expose `/api/settings` endpoints
- add `SettingsService` in Flutter
- fetch settings on startup to set theme
- allow toggling dark mode and notifications in profile screen

## Testing
- `phpunit` *(fails: phpunit not found)*
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b1fd597c8832f91f572f454e03457