### PR TITLE
Add badge system

### DIFF
--- a/flutterapp/lib/screens/profile_screen.dart
+++ b/flutterapp/lib/screens/profile_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../services/api_service.dart';
 import '../services/secure_auth_service.dart';
 import 'login_screen.dart';
+import '../widgets/badge_wall.dart';
 
 class ProfileScreen extends StatefulWidget {
   const ProfileScreen({super.key});
@@ -14,6 +15,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
   final ApiService _api = ApiService();
   final SecureAuthService _auth = SecureAuthService();
   Map<String, dynamic>? _profile;
+  List<dynamic>? _badges;
 
   @override
   void initState() {
@@ -25,7 +27,11 @@ class _ProfileScreenState extends State<ProfileScreen> {
     final token = await _auth.getToken();
     if (token == null) return;
     final data = await _api.getProfile(token);
-    setState(() => _profile = data);
+    final badges = await _api.getUserBadges(token);
+    setState(() {
+      _profile = data;
+      _badges = badges;
+    });
   }
 
   Future<void> _logout() async {
@@ -45,11 +51,17 @@ class _ProfileScreenState extends State<ProfileScreen> {
           IconButton(onPressed: _logout, icon: const Icon(Icons.logout))
         ],
       ),
-      body: Center(
-        child: _profile == null
-            ? const CircularProgressIndicator()
-            : Text('Hello ${_profile!['name'] ?? ''}'),
-      ),
+      body: _profile == null
+          ? const Center(child: CircularProgressIndicator())
+          : Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text('Hello ${_profile!['name'] ?? ''}'),
+                const SizedBox(height: 20),
+                if (_badges != null)
+                  Expanded(child: BadgeWall(badges: List<Map<String, dynamic>>.from(_badges!))),
+              ],
+            ),
     );
   }
 }

--- a/flutterapp/lib/services/api_service.dart
+++ b/flutterapp/lib/services/api_service.dart
@@ -37,4 +37,23 @@ class ApiService {
     }
     return null;
   }
+
+  Future<List<dynamic>> getBadges() async {
+    final response = await http.get(Uri.parse('$baseUrl/api/badges'));
+    if (response.statusCode == 200) {
+      return jsonDecode(response.body) as List<dynamic>;
+    }
+    return [];
+  }
+
+  Future<List<dynamic>> getUserBadges(String token) async {
+    final response = await http.get(
+      Uri.parse('$baseUrl/api/user/badges'),
+      headers: {'Authorization': 'Bearer $token'},
+    );
+    if (response.statusCode == 200) {
+      return jsonDecode(response.body) as List<dynamic>;
+    }
+    return [];
+  }
 }

--- a/flutterapp/lib/widgets/badge_wall.dart
+++ b/flutterapp/lib/widgets/badge_wall.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+class BadgeWall extends StatefulWidget {
+  final List<Map<String, dynamic>> badges;
+  const BadgeWall({super.key, required this.badges});
+
+  @override
+  State<BadgeWall> createState() => _BadgeWallState();
+}
+
+class _BadgeWallState extends State<BadgeWall>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller =
+      AnimationController(vsync: this, duration: const Duration(milliseconds: 500));
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GridView.builder(
+      shrinkWrap: true,
+      gridDelegate:
+          const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 3),
+      itemCount: widget.badges.length,
+      itemBuilder: (context, index) {
+        final badge = widget.badges[index];
+        return FadeTransition(
+          opacity: _controller,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(Icons.emoji_events, size: 40, color: Colors.amber),
+              Text(badge['name'] ?? ''),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/flutterapp/test/badge_wall_test.dart
+++ b/flutterapp/test/badge_wall_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutterapp/widgets/badge_wall.dart';
+
+void main() {
+  testWidgets('BadgeWall shows badges', (WidgetTester tester) async {
+    final badges = [
+      {'name': 'A'},
+      {'name': 'B'},
+    ];
+    await tester.pumpWidget(MaterialApp(home: BadgeWall(badges: badges)));
+    expect(find.text('A'), findsOneWidget);
+    expect(find.text('B'), findsOneWidget);
+  });
+}

--- a/laravel/app/Models/Badge.php
+++ b/laravel/app/Models/Badge.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Badge extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name', 'description', 'xp_threshold'];
+
+    public function users()
+    {
+        return $this->belongsToMany(User::class, 'user_badges')->withTimestamps();
+    }
+}

--- a/laravel/database/factories/BadgeFactory.php
+++ b/laravel/database/factories/BadgeFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Badge>
+ */
+class BadgeFactory extends Factory
+{
+    protected $model = \App\Models\Badge::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->word(),
+            'description' => $this->faker->sentence(),
+            'xp_threshold' => $this->faker->numberBetween(0, 100),
+        ];
+    }
+}

--- a/laravel/database/migrations/2025_07_06_150000_create_badges_table.php
+++ b/laravel/database/migrations/2025_07_06_150000_create_badges_table.php
@@ -1,0 +1,23 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('badges', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('description')->nullable();
+            $table->unsignedInteger('xp_threshold')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('badges');
+    }
+};

--- a/laravel/database/migrations/2025_07_06_150100_create_user_badges_table.php
+++ b/laravel/database/migrations/2025_07_06_150100_create_user_badges_table.php
@@ -1,0 +1,23 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('user_badges', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('badge_id')->constrained('badges')->cascadeOnDelete();
+            $table->timestamps();
+            $table->unique(['user_id', 'badge_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('user_badges');
+    }
+};

--- a/laravel/database/migrations/2025_07_06_150200_add_xp_to_users_table.php
+++ b/laravel/database/migrations/2025_07_06_150200_add_xp_to_users_table.php
@@ -1,0 +1,21 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->unsignedInteger('xp')->default(0);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('xp');
+        });
+    }
+};

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Requests\Auth\LoginRequest;
 use App\Models\User;
+use App\Models\Badge;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -11,6 +12,7 @@ Route::post('/login', function (LoginRequest $request) {
     $request->authenticate();
     $user = $request->user();
     $token = $user->createToken('api-token')->plainTextToken;
+    $user->addXp(10);
     return response()->json(['token' => $token, 'user' => $user]);
 });
 
@@ -26,6 +28,7 @@ Route::post('/register', function (Request $request) {
         'email' => $attributes['email'],
         'password' => Hash::make($attributes['password']),
     ]);
+    $user->syncBadges();
 
     $token = $user->createToken('api-token')->plainTextToken;
 
@@ -39,3 +42,12 @@ Route::middleware('auth:sanctum')->get('/profile', function (Request $request) {
 Route::middleware('auth:sanctum')->post('/logout', function (Request $request) {
     $request->user()->currentAccessToken()->delete();
     return response()->json([], 204);
+});
+
+Route::get('/badges', function () {
+    return Badge::all();
+});
+
+Route::middleware('auth:sanctum')->get('/user/badges', function (Request $request) {
+    return $request->user()->badges;
+});

--- a/laravel/tests/Feature/BadgeApiTest.php
+++ b/laravel/tests/Feature/BadgeApiTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use App\Models\Badge;
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+
+it('lists all badges', function () {
+    Badge::factory()->count(2)->create();
+    $response = $this->getJson('/api/badges');
+    $response->assertOk()->assertJsonCount(2);
+});
+
+it('lists user badges', function () {
+    $user = User::factory()->create();
+    $badge = Badge::factory()->create();
+    $user->badges()->attach($badge->id);
+
+    Sanctum::actingAs($user);
+    $response = $this->getJson('/api/user/badges');
+    $response->assertOk()->assertJsonCount(1);
+});
+


### PR DESCRIPTION
## Summary
- create migrations for badges and user_badges tables
- add XP column and badge models
- update routes to grant and expose badges
- extend API service and profile screen to show badges
- build animated BadgeWall widget
- add tests for badge API and widget

## Testing
- `php artisan test` *(fails: `php` not found)*
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b1fd82c1c832fb0f1a601bb46d036