### PR TITLE
Implement basic experimentation system

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ flutter run --dart-define=API_URL=http://localhost:8000
 
 In Laravel, configure `APP_URL` and your database credentials in `.env`.
 
+## Experiments API
+
+Authenticated users can call `/api/experiments` to retrieve their assigned variant for each experiment. The Flutter app uses this endpoint to adapt its UI.
+
 ## Swagger UI
 
 Pour consulter la documentation de l'API :

--- a/flutterapp/lib/screens/profile_screen.dart
+++ b/flutterapp/lib/screens/profile_screen.dart
@@ -14,6 +14,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
   final ApiService _api = ApiService();
   final SecureAuthService _auth = SecureAuthService();
   Map<String, dynamic>? _profile;
+  Map<String, dynamic> _experiments = {};
 
   @override
   void initState() {
@@ -25,7 +26,11 @@ class _ProfileScreenState extends State<ProfileScreen> {
     final token = await _auth.getToken();
     if (token == null) return;
     final data = await _api.getProfile(token);
-    setState(() => _profile = data);
+    final exps = await _api.getExperiments(token);
+    setState(() {
+      _profile = data;
+      _experiments = exps;
+    });
   }
 
   Future<void> _logout() async {
@@ -45,11 +50,25 @@ class _ProfileScreenState extends State<ProfileScreen> {
           IconButton(onPressed: _logout, icon: const Icon(Icons.logout))
         ],
       ),
-      body: Center(
-        child: _profile == null
-            ? const CircularProgressIndicator()
-            : Text('Hello ${_profile!['name'] ?? ''}'),
-      ),
+        body: Center(
+          child: _profile == null
+              ? const CircularProgressIndicator()
+              : _buildContent(),
+        ),
+      );
+  }
+
+  Widget _buildContent() {
+    String greeting = 'Hello ${_profile!["name"] ?? ''}';
+    if (_experiments['welcome_message'] == 'new') {
+      greeting = 'Welcome to the new profile, ${_profile!["name"]}';
+    }
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Text(greeting),
+        if (_experiments.isNotEmpty) Text('Experiment: ${_experiments}'),
+      ],
     );
   }
 }

--- a/flutterapp/lib/services/api_service.dart
+++ b/flutterapp/lib/services/api_service.dart
@@ -37,4 +37,15 @@ class ApiService {
     }
     return null;
   }
+
+  Future<Map<String, dynamic>> getExperiments(String token) async {
+    final response = await http.get(
+      Uri.parse('$baseUrl/api/experiments'),
+      headers: {'Authorization': 'Bearer $token'},
+    );
+    if (response.statusCode == 200) {
+      return jsonDecode(response.body) as Map<String, dynamic>;
+    }
+    return {};
+  }
 }

--- a/laravel/app/Http/Controllers/API/ExperimentController.php
+++ b/laravel/app/Http/Controllers/API/ExperimentController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Models\Experiment;
+use App\Models\ExperimentAssignment;
+use Illuminate\Http\Request;
+
+class ExperimentController extends Controller
+{
+    public function assignments(Request $request)
+    {
+        $user = $request->user();
+        $results = [];
+
+        foreach (Experiment::all() as $experiment) {
+            $assignment = ExperimentAssignment::firstOrCreate(
+                ['user_id' => $user->id, 'experiment_id' => $experiment->id],
+                ['variant' => collect($experiment->variants)->random()]
+            );
+
+            $results[$experiment->key] = $assignment->variant;
+        }
+
+        return response()->json($results);
+    }
+}

--- a/laravel/app/Models/Experiment.php
+++ b/laravel/app/Models/Experiment.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Experiment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'key',
+        'variants',
+    ];
+
+    protected $casts = [
+        'variants' => 'array',
+    ];
+}

--- a/laravel/app/Models/ExperimentAssignment.php
+++ b/laravel/app/Models/ExperimentAssignment.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ExperimentAssignment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'experiment_id',
+        'variant',
+    ];
+
+    public function experiment()
+    {
+        return $this->belongsTo(Experiment::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/laravel/database/migrations/2025_07_06_150000_create_experiments_table.php
+++ b/laravel/database/migrations/2025_07_06_150000_create_experiments_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('experiments', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->json('variants');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('experiments');
+    }
+};

--- a/laravel/database/migrations/2025_07_06_150100_create_experiment_assignments_table.php
+++ b/laravel/database/migrations/2025_07_06_150100_create_experiment_assignments_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('experiment_assignments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('experiment_id')->constrained()->onDelete('cascade');
+            $table->string('variant');
+            $table->timestamps();
+            $table->unique(['user_id', 'experiment_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('experiment_assignments');
+    }
+};

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -39,3 +39,7 @@ Route::middleware('auth:sanctum')->get('/profile', function (Request $request) {
 Route::middleware('auth:sanctum')->post('/logout', function (Request $request) {
     $request->user()->currentAccessToken()->delete();
     return response()->json([], 204);
+});
+
+Route::middleware('auth:sanctum')->get('/experiments', [\App\Http\Controllers\API\ExperimentController::class, 'assignments']);
+

--- a/laravel/tests/Feature/ExperimentTest.php
+++ b/laravel/tests/Feature/ExperimentTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use App\Models\Experiment;
+use App\Models\ExperimentAssignment;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+
+it('assigns a variant on first call', function () {
+    $user = User::factory()->create();
+    $experiment = Experiment::create([
+        'key' => 'welcome_message',
+        'variants' => ['control', 'new'],
+    ]);
+
+    Sanctum::actingAs($user);
+
+    $response = $this->getJson('/api/experiments');
+
+    $response->assertOk()->assertJsonStructure([
+        'welcome_message',
+    ]);
+
+    $variant = ExperimentAssignment::where('user_id', $user->id)->first();
+    expect($variant)->not->toBeNull();
+});


### PR DESCRIPTION
## Summary
- add experiments tables and models in Laravel
- implement API endpoint to assign and return experiment variants
- expose assignments to Flutter and display variant-based greeting
- document the new API

## Testing
- `composer test` *(fails: composer not found)*
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b1fd89fb8832f90fb99270b983b04