### PR TITLE
Add offline sync support

### DIFF
--- a/flutterapp/lib/main.dart
+++ b/flutterapp/lib/main.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'services/secure_auth_service.dart';
+import 'services/sync_service.dart';
 import 'screens/login_screen.dart';
 import 'screens/profile_screen.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await dotenv.load(fileName: '.env');
+  final sync = SyncService();
+  await sync.init();
   final auth = SecureAuthService();
   final token = await auth.getToken();
   runApp(MyApp(initialToken: token));

--- a/flutterapp/lib/services/api_service.dart
+++ b/flutterapp/lib/services/api_service.dart
@@ -37,4 +37,16 @@ class ApiService {
     }
     return null;
   }
+
+  Future<bool> syncRecords(String token, List<Map<String, dynamic>> records) async {
+    final response = await http.post(
+      Uri.parse('$baseUrl/api/sync'),
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $token',
+      },
+      body: jsonEncode({'records': records}),
+    );
+    return response.statusCode == 200;
+  }
 }

--- a/flutterapp/lib/services/sync_service.dart
+++ b/flutterapp/lib/services/sync_service.dart
@@ -1,0 +1,45 @@
+import 'package:hive/hive.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'api_service.dart';
+import 'secure_auth_service.dart';
+
+class SyncService {
+  static const _boxName = 'queued_actions';
+  static const _key = 'actions';
+
+  final ApiService _api;
+  final SecureAuthService _auth;
+  late Box _box;
+
+  SyncService({ApiService? api, SecureAuthService? auth})
+      : _api = api ?? ApiService(),
+        _auth = auth ?? SecureAuthService();
+
+  Future<void> init() async {
+    await Hive.initFlutter();
+    _box = await Hive.openBox(_boxName);
+    Connectivity().onConnectivityChanged.listen((result) {
+      if (result != ConnectivityResult.none) {
+        flushQueue();
+      }
+    });
+  }
+
+  Future<void> queueAction(Map<String, dynamic> action) async {
+    final List<dynamic> list = _box.get(_key, defaultValue: <dynamic>[]) as List<dynamic>;
+    list.add(action);
+    await _box.put(_key, list);
+  }
+
+  Future<void> flushQueue() async {
+    final List<dynamic> list = _box.get(_key, defaultValue: <dynamic>[]) as List<dynamic>;
+    if (list.isEmpty) return;
+    final token = await _auth.getToken();
+    if (token == null) return;
+    final success = await _api.syncRecords(token, List<Map<String, dynamic>>.from(list));
+    if (success) {
+      await _box.put(_key, <dynamic>[]);
+    }
+  }
+}

--- a/flutterapp/pubspec.yaml
+++ b/flutterapp/pubspec.yaml
@@ -37,6 +37,10 @@ dependencies:
   http: ^1.1.0
   flutter_dotenv: ^5.0.2
   flutter_secure_storage: ^9.0.0
+  hive: ^2.2.3
+  hive_flutter: ^1.1.0
+  path_provider: ^2.0.15
+  connectivity_plus: ^6.0.3
 
 dev_dependencies:
   flutter_test:

--- a/laravel/app/Http/Controllers/API/SyncController.php
+++ b/laravel/app/Http/Controllers/API/SyncController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Models\Record;
+use Illuminate\Http\Request;
+
+class SyncController extends Controller
+{
+    public function store(Request $request)
+    {
+        $request->validate([
+            'records' => 'required|array',
+        ]);
+
+        $user = $request->user();
+
+        foreach ($request->input('records') as $record) {
+            Record::create([
+                'user_id' => $user->id,
+                'data' => $record,
+            ]);
+        }
+
+        return response()->json(['status' => 'synced']);
+    }
+}

--- a/laravel/app/Models/Record.php
+++ b/laravel/app/Models/Record.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Record extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'data',
+    ];
+
+    protected $casts = [
+        'data' => 'array',
+    ];
+}

--- a/laravel/database/migrations/2025_07_06_141450_create_records_table.php
+++ b/laravel/database/migrations/2025_07_06_141450_create_records_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('records', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->json('data');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('records');
+    }
+};

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Requests\Auth\LoginRequest;
+use App\Http\Controllers\API\SyncController;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Http\Request;
@@ -17,7 +18,7 @@ Route::post('/login', function (LoginRequest $request) {
 Route::post('/register', function (Request $request) {
     $attributes = $request->validate([
         'name' => ['required', 'string', 'max:255'],
-        'email' => ['required', 'string', 'email', 'max:255', 'unique:'.User::class],
+        'email' => ['required', 'string', 'email', 'max:255', 'unique:' . User::class],
         'password' => ['required', 'string', 'confirmed'],
     ]);
 
@@ -39,3 +40,6 @@ Route::middleware('auth:sanctum')->get('/profile', function (Request $request) {
 Route::middleware('auth:sanctum')->post('/logout', function (Request $request) {
     $request->user()->currentAccessToken()->delete();
     return response()->json([], 204);
+});
+
+Route::middleware('auth:sanctum')->post('/sync', [SyncController::class, 'store']);

--- a/laravel/tests/Feature/SyncApiTest.php
+++ b/laravel/tests/Feature/SyncApiTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+use App\Models\Record;
+
+it('stores records from sync endpoint', function () {
+    $user = User::factory()->create();
+
+    Sanctum::actingAs($user);
+
+    $payload = [
+        'records' => [
+            ['foo' => 'bar'],
+            ['baz' => 123],
+        ],
+    ];
+
+    $response = $this->postJson('/api/sync', $payload);
+
+    $response->assertOk()->assertJson(['status' => 'synced']);
+
+    expect(Record::count())->toBe(2);
+});


### PR DESCRIPTION
## Summary
- create a Laravel `Record` model and migration
- add `/api/sync` endpoint to store offline records
- provide a pest test covering the new endpoint
- add Hive-based `SyncService` in Flutter
- support syncing queued actions and init service on startup
- update pubspec with Hive and connectivity dependencies

## Testing
- `php artisan test` *(fails: php not installed)*
- `flutter pub get` *(fails: flutter not installed)*
- `dart test` *(fails: dart not installed)*
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686b1fd9192c832fb14b9a56004dc05d